### PR TITLE
Add feature to fix destination hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.dump
 *.tar.gz
 __pycache__/*
+process/__pycache__/*

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ python3 main.py -j <filename>.json --src-address <ip_address> --src-port <port> 
 ```
 
 #### Output example
-1. For the complete migration go to the following link:  
-https://asciinema.org/a/40740
+##### Complete Migration Result
+[![asciicast](https://asciinema.org/a/40740.png)](https://asciinema.org/a/40740)
 
-2. For the fix destination hostname feature go to the following link:  
-https://asciinema.org/a/1ah6seolg5jipt98o75wca4wm
+##### Fix Destination Hostname Feature
+[![asciicast](https://asciinema.org/a/1ah6seolg5jipt98o75wca4wm.png)](https://asciinema.org/a/1ah6seolg5jipt98o75wca4wm)
 
 ### Architecture
 ![alt tag](https://raw.githubusercontent.com/wizeservices/wordpress-migration-cli/develop/docs/Architecture.png)

--- a/README.md
+++ b/README.md
@@ -89,51 +89,11 @@ python3 main.py -j <filename>.json --src-address <ip_address> --src-port <port> 
 ```
 
 #### Output example
-Go to the following link:
+1. For the complete migration go to the following link:  
 https://asciinema.org/a/40740
+
+2. For the fix destination hostname feature go to the following link:  
+https://asciinema.org/a/1ah6seolg5jipt98o75wca4wm
 
 ### Architecture
 ![alt tag](https://raw.githubusercontent.com/wizeservices/wordpress-migration-cli/develop/docs/Architecture.png)
-
-### Reference
-```
-usage: main.py [-h] [-l {debug,info,warning,error}] [-n] [-j JSON_FILE]
-               [--src-address SRC_ADDRESS] [--src-port SRC_PORT]
-               [--src_filekey SRC_FILEKEY] [--src-user SRC_USER]
-               [--src-passw SRC_PASSW] [--src-wpath SRC_WPATH]
-               [--dest-address DEST_ADDRESS] [--dest-port DEST_PORT]
-               [--dest_filekey DEST_FILEKEY] [--dest-user DEST_USER]
-               [--dest-passw DEST_PASSW] [--dest-wpath DEST_WPATH]
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -l {debug,info,warning,error}, --log-level {debug,info,warning,error}
-                        Load the parameters from a json file
-  -n, --no-cache        Run the client without cache
-  -j JSON_FILE, --json-file JSON_FILE
-                        Load the parameters from a json file
-  --src-address SRC_ADDRESS
-                        The address of the source machine
-  --src-port SRC_PORT   The port of the source machine
-  --src_filekey SRC_FILEKEY
-                        The ssh private key file for the source machine
-  --src-user SRC_USER   The username to use to connect to the sourcemachine
-  --src-passw SRC_PASSW
-                        The password to use to connect top the sourcemachine
-  --src-wpath SRC_WPATH
-                        Set wordpress path for the source machine
-  --dest-address DEST_ADDRESS
-                        The address of the destination machine
-  --dest-port DEST_PORT
-                        The port of the destination machine
-  --dest_filekey DEST_FILEKEY
-                        The ssh private key file for the destination machine
-  --dest-user DEST_USER
-                        The username to use to connect to the destination
-                        machine
-  --dest-passw DEST_PASSW
-                        The password to use to connect top the destination
-                        machine
-  --dest-wpath DEST_WPATH
-                        Set wordpress path for the destination machine
-```

--- a/README.md
+++ b/README.md
@@ -89,48 +89,11 @@ python3 main.py -j <filename>.json --src-address <ip_address> --src-port <port> 
 ```
 
 #### Output example
-```
-16:34:28.585 - INFO - migration.py - Connecting to mydomain
-16:34:29.205 - INFO - migration.py - Connection successful
-16:34:29.208 - INFO - migration.py - Connecting to 127.0.0.1
-16:34:29.326 - INFO - migration.py - Connection successful
-16:34:29.326 - INFO - migration.py - Starts "Reading wp-config.php from destination"
-16:34:29.655 - INFO - migration.py - Done "Reading wp-config.php from destination"
-16:34:29.655 - INFO - migration.py - Starts "Get site url from destination"
-16:34:29.892 - INFO - migration.py - Done "Get site url from destination"
-16:34:29.892 - INFO - migration.py - Starts "Get site url from source"
-16:34:30.221 - INFO - migration.py - Done "Get site url from source"
-16:34:30.221 - INFO - migration.py - Starts "Creating wordpress database dump from source"
-16:34:31.692 - INFO - migration.py - Done "Creating wordpress database dump from source"
-16:34:31.692 - INFO - migration.py - Starts "Downloading wordpress database dump from source"
-16:34:34.610 - INFO - migration.py - Done "Downloading wordpress database dump from source"
-16:34:34.610 - INFO - migration.py - Starts "Creating tar file"
-16:34:36.863 - INFO - migration.py - Done "Creating tar file"
-16:34:36.863 - INFO - migration.py - Starts "Downloading tar file from source"
-16:35:09.333 - INFO - migration.py - Done "Downloading tar file from source"
-16:35:09.333 - INFO - migration.py - Starts "Uploading database dump to destination"
-16:35:13.359 - INFO - migration.py - Done "Uploading database dump to destination"
-16:35:13.359 - INFO - migration.py - Starts "Uploading wordpress tar file dump to destination"
-16:35:17.923 - INFO - migration.py - Done "Uploading wordpress tar file dump to destination"
-16:35:17.924 - INFO - migration.py - Starts "Creating database dump from destination"
-16:35:19.840 - INFO - migration.py - Done "Creating database dump from destination"
-16:35:19.841 - INFO - migration.py - Starts "Creating wordpress tar file from destination"
-16:35:20.020 - INFO - migration.py - Done "Creating wordpress tar file from destination"
-16:35:20.020 - INFO - migration.py - Starts "Decompressing wordpress source in destination"
-16:35:21.987 - INFO - migration.py - Done "Decompressing wordpress source in destination"
-16:35:21.987 - INFO - migration.py - Starts "Erasing previous wordpress contents from destination"
-16:35:22.040 - INFO - migration.py - Done "Erasing previous wordpress contents from destination"
-16:35:22.040 - INFO - migration.py - Starts "Copying source backup into destination folder"
-16:35:22.944 - INFO - migration.py - Done "Copying source backup into destination folder"
-16:35:22.944 - INFO - migration.py - Starts "Replacing original database creadential in wp-config.php"
-16:35:22.976 - INFO - migration.py - Done "Replacing original database creadential in wp-config.php"
-16:35:22.976 - INFO - migration.py - Starts "Importing DB dump in destination"
-16:35:24.070 - INFO - migration.py - Done "Importing DB dump in destination"
-16:35:24.070 - INFO - migration.py - Migration complete
-```
+Go to the following link:
+https://asciinema.org/a/40740
 
 ### Architecture
-![alt tag](https://raw.githubusercontent.com/wizeservices/wordpress-migration-cli/feat/new-model/docs/Architecture.png)
+![alt tag](https://raw.githubusercontent.com/wizeservices/wordpress-migration-cli/develop/docs/Architecture.png)
 
 ### Reference
 ```

--- a/main.py
+++ b/main.py
@@ -38,6 +38,13 @@ def handle_options():
     parser.add_argument('-n', '--no-cache', action='store_true',
                         help='Run the client without cache')
 
+    parser.add_argument('--fix-destination-hostname', action='store_true',
+                        help='Change the hostname on wp_config and in the DB')
+    parser.add_argument('--current-site', action='store',
+                        help='Only valid when --fix-destination-hostname')
+    parser.add_argument('--new-site', action='store',
+                        help='Only valid when --fix-destination-hostname')
+
     parser.add_argument('--no-users', action='store_true',
                         help='Omit users in migration')
     parser.add_argument('--no-posts', action='store_true',

--- a/migration.py
+++ b/migration.py
@@ -2,7 +2,9 @@ import json
 import os
 import os.path
 
-import process
+import process.common
+import process.all
+import process.fix
 import lib
 
 
@@ -21,42 +23,64 @@ class Migration(object):
             self._init_processes_normal()
 
     def _init_processes_normal(self):
-        self.processes.append(process.SSHConnectSource())
+        self.info['type'] = 'all'
+        self.processes.append(process.common.SSHConnectSourceProcess())
         # Force to always connect to the source
         self.processes[-1].required = True
-        self.processes.append(process.SSHConnectDestination())
+        self.processes.append(process.common.SSHConnectDestinationProcess())
         # Force to always connect to the destination
         self.processes[-1].required = True
-        self.processes.append(process.DestGetDBCredentialsProcess())
-        self.processes.append(process.DestGetSiteUrlProcess())
-        self.processes.append(process.SrcGetSiteUrlProcess())
-        self.processes.append(process.SrcGetTableList())
-        self.processes.append(process.SrcDoDBBackup())
-        self.processes.append(process.SrcDownloadDBBackup())
-        self.processes.append(process.SrcDoTar())
-        self.processes.append(process.SrcDownloadTar())
-        self.processes.append(process.DestUploadDatabaseDump())
-        self.processes.append(process.DestUploadTar())
-        self.processes.append(process.DestCreateDBBackup())
-        self.processes.append(process.DestCreateWPBackup())
-        self.processes.append(process.DestDecompressWordpress())
-        self.processes.append(process.DestErasePreviousWordpress())
-        self.processes.append(process.DestCopyWPBackup())
-        self.processes.append(process.DestReplaceConf())
-        self.processes.append(process.DestImportDBDump())
+        self.processes.append(process.all.DestGetDBCredentialsProcess())
+        self.processes.append(process.all.DestGetSiteUrlProcess())
+        self.processes.append(process.all.SrcGetSiteUrlProcess())
+        self.processes.append(process.all.SrcGetTableListProcess())
+        self.processes.append(process.all.SrcDoDBBackupProcess())
+        self.processes.append(process.all.SrcDownloadDBBackupProcess())
+        self.processes.append(process.all.SrcDoTarProcess())
+        self.processes.append(process.all.SrcDownloadTarProcess())
+        self.processes.append(process.all.DestUploadDatabaseDumpProcess())
+        self.processes.append(process.all.DestUploadTarProcess())
+        self.processes.append(process.all.DestCreateDBBackupProcess())
+        self.processes.append(process.all.DestCreateWPBackupProcess())
+        self.processes.append(process.all.DestDecompressWordpressProcess())
+        self.processes.append(process.all.DestErasePreviousWordpressProcess())
+        self.processes.append(process.all.DestCopyWPBackupProcess())
+        self.processes.append(process.common.DestReplaceConfProcess())
+        self.processes.append(process.all.DestImportDBDumpProcess())
         if self.args.no_posts:
-            self.processes.append(process.DestTruncatePosts())
+            self.processes.append(process.all.DestTruncatePostsProcess())
 
     def _init_processes_fix_destination(self):
-        pass
+        if self.args.current_site is None or self.args.current_site == '':
+            lib.log.error('Missing current site')
+            exit(-1)
+        if self.args.new_site is None or self.args.new_site == '':
+            lib.log.error('Missing new site')
+            exit(-1)
+        self.info['conf']['wp-config'] = \
+            {'DOMAIN_CURRENT_SITE': self.args.new_site,
+             'SRC_DOMAIN_CURRENT_SITE': self.args.current_site}
+        self.info['type'] = 'fix'
+        self.processes.append(process.common.SSHConnectDestinationProcess())
+        # Force to always connect to the destination
+        self.processes[-1].required = True
+        self.processes.append(process.fix.DestGetTableListProcess())
+        self.processes.append(process.fix.DestDoDBBackupProcess())
+        self.processes.append(process.common.DestReplaceConfProcess())
 
     def execute(self):
         """Will loop over the list of processes to execute each of them"""
-
+        tmp_info = None
         if not self.args.no_cache and os.path.exists('.info.json'):
             with open('.info.json') as file:
                 lib.log.debug('Loading json file')
-                self.info = json.loads(file.read())
+                tmp_info = json.loads(file.read())
+
+        if tmp_info and ((self.args.fix_destination_hostname and
+             tmp_info['type'] == 'fix') or
+            (not self.args.fix_destination_hostname and
+             tmp_info['type'] == 'all')):
+            self.info = tmp_info
 
         tmp = [item for item in self.processes[:self.info['step']]
                if item.required]
@@ -66,15 +90,15 @@ class Migration(object):
                 proc.init()
                 lib.log.info('Starts "%s"', proc.name)
                 proc.execute(self.args, self.info['conf'])
+                lib.log.info('Done "%s"', proc.name)
                 self.info['step'] += 1
                 with open('.info.json', 'w') as file:
                     file.write(json.dumps(self.info))
                 lib.log.debug(self.info)
-                lib.log.info('Done "%s"', proc.name)
             except Exception as exc:
                 lib.log.error(exc)
                 break
         else:
             os.remove('.info.json')
             lib.log.info('Migration complete')
-        process.AbstractProcess.close_connections()
+        process.common.AbstractProcess.close_connections()

--- a/migration.py
+++ b/migration.py
@@ -2,9 +2,6 @@ import json
 import os
 import os.path
 
-import paramiko
-from paramiko import SSHClient
-
 import process
 import lib
 
@@ -18,9 +15,18 @@ class Migration(object):
         self.ssh_src = None
         self.ssh_dest = None
         self.processes = list()
-        self._init_processes()
+        if self.args.fix_destination_hostname:
+            self._init_processes_fix_destination()
+        else:
+            self._init_processes_normal()
 
-    def _init_processes(self):
+    def _init_processes_normal(self):
+        self.processes.append(process.SSHConnectSource())
+        # Force to always connect to the source
+        self.processes[-1].required = True
+        self.processes.append(process.SSHConnectDestination())
+        # Force to always connect to the destination
+        self.processes[-1].required = True
         self.processes.append(process.DestGetDBCredentialsProcess())
         self.processes.append(process.DestGetSiteUrlProcess())
         self.processes.append(process.SrcGetSiteUrlProcess())
@@ -41,30 +47,25 @@ class Migration(object):
         if self.args.no_posts:
             self.processes.append(process.DestTruncatePosts())
 
+    def _init_processes_fix_destination(self):
+        pass
+
     def execute(self):
         """Will loop over the list of processes to execute each of them"""
-        self.ssh_src = self._ssh_connect('src')
-        if self.ssh_src is None:
-            exit(-1)
-
-        self.ssh_dest = self._ssh_connect('dest')
-        if self.ssh_dest is None:
-            self.ssh_src.close()
-            exit(-1)
 
         if not self.args.no_cache and os.path.exists('.info.json'):
             with open('.info.json') as file:
                 lib.log.debug('Loading json file')
                 self.info = json.loads(file.read())
 
-        for proc in self.processes[self.info['step']:]:
+        tmp = [item for item in self.processes[:self.info['step']]
+               if item.required]
+        tmp.extend(self.processes[self.info['step']:])
+        for proc in tmp:
             try:
                 proc.init()
-                tmp = (self.ssh_src
-                       if proc.target == process.AbstractProcess.SRC
-                       else self.ssh_dest)
                 lib.log.info('Starts "%s"', proc.name)
-                proc.execute(tmp, self.args, self.info['conf'])
+                proc.execute(self.args, self.info['conf'])
                 self.info['step'] += 1
                 with open('.info.json', 'w') as file:
                     file.write(json.dumps(self.info))
@@ -76,35 +77,4 @@ class Migration(object):
         else:
             os.remove('.info.json')
             lib.log.info('Migration complete')
-
-        self.ssh_src.close()
-        self.ssh_dest.close()
-
-    def _ssh_connect(self, direction):
-        """Creates an ssh connection using the arguments provided"""
-        try:
-            ssh = SSHClient()
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.load_system_host_keys()
-            address = self.args.__getattribute__(direction + '_address')
-            port = self.args.__getattribute__(direction + '_port')
-            user = self.args.__getattribute__(direction + '_user')
-            passw = self.args.__getattribute__(direction + '_passw')
-            fkey = self.args.__getattribute__(direction + '_filekey')
-            lib.log.info('Connecting to %s', address)
-            if fkey:
-                key = paramiko.RSAKey.from_private_key_file(fkey)
-                # In case you need to set an user
-                if user:
-                    ssh.connect(address, port=port, username=user, pkey=key)
-                else:
-                    ssh.connect(address, port=port, pkey=key)
-            else:
-                ssh.connect(address, port=port, username=user, password=passw)
-            lib.log.info('Connection successful')
-            return ssh
-        except Exception as exc:
-            # 'dict_keys' object is not subscriptable
-            # It means that the connection was not successful
-            lib.log.error('Unable to connect: ' + str(exc))
-        return None
+        process.AbstractProcess.close_connections()

--- a/process.py
+++ b/process.py
@@ -197,7 +197,6 @@ class DestTruncatePosts(AbstractProcess):
         status = stdout.channel.recv_exit_status()
         content = stderr.read().decode('utf-8').replace('\n', '')
         if status != 0 or 'ERROR' in content:
-            import pdb; pdb.set_trace()
             raise Exception(content)
 
 

--- a/process/common.py
+++ b/process/common.py
@@ -1,0 +1,109 @@
+from abc import ABCMeta, abstractmethod
+
+import paramiko
+from paramiko import SSHClient
+
+import lib
+
+
+class AbstractProcess(object):
+    """Class which defines the process interface"""
+    __metaclass__ = ABCMeta
+    DEST = 0
+    SRC = 1
+    CONS = dict()
+
+    def __init__(self):
+        self.name = None
+        self.target = None
+        self.required = False
+
+    @staticmethod
+    def close_connections():
+        for key in AbstractProcess.CONS:
+            AbstractProcess.CONS[key].close()
+
+    @abstractmethod
+    def init(self):
+        """Initializes the name and target"""
+        pass
+
+    @abstractmethod
+    def execute(self, args, conf):
+        """Implements the command to be run"""
+        pass
+
+
+def _ssh_connect(args, direction):
+    """Creates an ssh connection using the arguments provided"""
+    try:
+        ssh = SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.load_system_host_keys()
+        address = args.__getattribute__(direction + '_address')
+        port = args.__getattribute__(direction + '_port')
+        user = args.__getattribute__(direction + '_user')
+        passw = args.__getattribute__(direction + '_passw')
+        fkey = args.__getattribute__(direction + '_filekey')
+        lib.log.info('Connecting to %s', address)
+        if fkey:
+            key = paramiko.RSAKey.from_private_key_file(fkey)
+            # In case you need to set an user
+            if user:
+                ssh.connect(address, port=port, username=user, pkey=key)
+            else:
+                ssh.connect(address, port=port, pkey=key)
+        else:
+            ssh.connect(address, port=port, username=user, password=passw)
+        lib.log.info('Connection successful')
+        return ssh
+    except Exception as exc:
+        # 'dict_keys' object is not subscriptable
+        # It means that the connection was not successful
+        lib.log.error('Unable to connect: ' + str(exc))
+        exit(-1)
+    return None
+
+
+class SSHConnectSourceProcess(AbstractProcess):
+    """Creates wp database dump"""
+
+    def init(self):
+        self.target = AbstractProcess.SRC
+        self.name = 'Connecting to source'
+
+    def execute(self, args, conf):
+        AbstractProcess.CONS[self.target] = _ssh_connect(args, 'src')
+
+
+class SSHConnectDestinationProcess(AbstractProcess):
+    """Creates wp database dump"""
+
+    def init(self):
+        self.target = AbstractProcess.DEST
+        self.name = 'Connecting to destination'
+
+    def execute(self, args, conf):
+        AbstractProcess.CONS[self.target] = _ssh_connect(args, 'dest')
+
+
+class DestReplaceConfProcess(AbstractProcess):
+    """Replaces database credentials in wp-config.php"""
+
+    def init(self):
+        self.target = AbstractProcess.DEST
+        self.name = 'Replacing original database credential in wp-config.php'
+
+    def execute(self, args, conf):
+        ssh = AbstractProcess.CONS[self.target]
+        for key in conf['wp-config']:
+            cmd = ("sed -i \"s/{0}'[^']*'[^']*/{0}', '{1}/g\""
+                   " {2}/wp-config.php".format(key,
+                                               conf['wp-config'][key],
+                                               args.dest_wpath))
+            lib.log.debug(cmd)
+            _, stdout, _ = ssh.exec_command(cmd)
+            status = stdout.channel.recv_exit_status()
+            if status != 0:
+                lib.log.warning('Unable to execute %s (status = %d)', cmd,
+                                status)

--- a/process/fix.py
+++ b/process/fix.py
@@ -1,0 +1,53 @@
+
+import lib
+from process.common import AbstractProcess
+
+class DestDoDBBackupProcess(AbstractProcess):
+    """Creates the wp backup for the database"""
+
+    def init(self):
+        self.target = AbstractProcess.DEST
+        self.name = 'Creating wordpress database dump from source'
+
+    def execute(self, args, conf):
+        ssh = AbstractProcess.CONS[self.target]
+        cmd = ('wp --allow-root --path={} search-replace --network --precise '
+               '{} {} {}'
+               .format(args.dest_wpath,
+                       conf['wp-config']['SRC_DOMAIN_CURRENT_SITE'],
+                       conf['wp-config']['DOMAIN_CURRENT_SITE'],
+                       ' '.join(conf['tables'])))
+        lib.log.debug(cmd)
+        _, stdout, stderr = ssh.exec_command(cmd)
+        status = stdout.channel.recv_exit_status()
+        if status != 0:
+            raise Exception(stderr.read().decode('utf-8'))
+
+
+class DestGetTableListProcess(AbstractProcess):
+    """Gathers the list of tables
+    """
+
+    def init(self):
+        self.target = AbstractProcess.DEST
+        self.name = 'Get list of tables from destination'
+
+    def execute(self, args, conf):
+        ssh = AbstractProcess.CONS[self.target]
+        cmd = ('wp --allow-root --path={} db tables \'wp_*\' --format=csv'
+               .format(args.dest_wpath))
+        lib.log.debug(cmd)
+        _, stdout, stderr = ssh.exec_command(cmd)
+        content = stdout.read().decode('utf-8').replace('\n', '')
+        status = stdout.channel.recv_exit_status()
+        if status != 0:
+            raise Exception(stderr.read().decode('utf-8'))
+
+        conf['tables'] = content.split(',')
+        tmp = list()
+        if args.no_users:
+            for item in conf['tables']:
+                if 'user' in item:
+                    continue
+                tmp.append(item)
+            conf['tables'] = tmp


### PR DESCRIPTION
#### What does this PR do?

Refactor code and add command line arguments to fix the destination hostname.
#### Where should the reviewer start?

You need a vagrant box with a wordpress installation.
#### How should this be manually tested?

If you already have a local vagrant box with a wordpress installation, do the following:
1. Modify the hostname in the Vagrant file.
2. Run `vagrant up`.
3. Run:  
   `python3 main.py -j vagrant.json --fix-destination-hostname --current-site <PREVIOUS-DOMAIN> --new-site <NEW_DOMAIN>`  
