### PR TITLE
Add --dest-sudo flag to run commands with sudo

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,10 @@ def handle_options():
     parser.add_argument('-n', '--no-cache', action='store_true',
                         help='Run the client without cache')
 
+    parser.add_argument('--dest-sudo', action='store_true',
+                        help='The destination username is not root and needs '
+                             'sudo')
+
     parser.add_argument('--fix-destination-hostname', action='store_true',
                         help='Change the hostname on wp_config and in the DB')
     parser.add_argument('--current-site', action='store',

--- a/process/all.py
+++ b/process/all.py
@@ -33,7 +33,10 @@ class DestCopyWPBackupProcess(AbstractProcess):
 
     def execute(self, args, conf):
         ssh = AbstractProcess.CONS[self.target]
-        cmd = 'cp -r /tmp/{}/* {}/'.format(args.src_wpath, args.dest_wpath)
+        sudo = 'sudo ' if args.dest_sudo else ''
+        cmd = '{}cp -r /tmp/{}/* {}/'.format(sudo,
+                                             args.src_wpath,
+                                             args.dest_wpath)
         lib.log.debug(cmd)
         _, stdout, stderr = ssh.exec_command(cmd)
         status = stdout.channel.recv_exit_status()
@@ -117,7 +120,8 @@ class DestErasePreviousWordpressProcess(AbstractProcess):
 
     def execute(self, args, conf):
         ssh = AbstractProcess.CONS[self.target]
-        cmd = 'rm -rf {}/*'.format(args.dest_wpath)
+        sudo = 'sudo ' if args.dest_sudo else ''
+        cmd = '{}rm -rf {}/*'.format(sudo, args.dest_wpath)
         lib.log.debug(cmd)
         _, stdout, stderr = ssh.exec_command(cmd)
         status = stdout.channel.recv_exit_status()

--- a/process/common.py
+++ b/process/common.py
@@ -97,8 +97,10 @@ class DestReplaceConfProcess(AbstractProcess):
     def execute(self, args, conf):
         ssh = AbstractProcess.CONS[self.target]
         for key in conf['wp-config']:
-            cmd = ("sed -i \"s/{0}'[^']*'[^']*/{0}', '{1}/g\""
-                   " {2}/wp-config.php".format(key,
+            sudo = 'sudo ' if args.dest_sudo else ''
+            cmd = ("{0}sed -i \"s/{1}'[^']*'[^']*/{1}', '{2}/g\""
+                   " {3}/wp-config.php".format(sudo,
+                                               key,
                                                conf['wp-config'][key],
                                                args.dest_wpath))
             lib.log.debug(cmd)


### PR DESCRIPTION
#### What does this PR do?

Adds a flag to activate sudo in the commands that need permission that the user used in the connection does not have.
#### Where should the reviewer start?
1. First you need one instance with content in wordpress.
2. In the second instance you need to have a clean wordpress installation.
3. Run the migration cli (**Note:** the user provided in the json should not be root in order to test the sudo flag):

```
python3 main.py -j example.json --dest-sudo
```
#### How should this be manually tested?
1. After the migration tool finishes, check if you have the same copy in the new instance.
