### PR TITLE
Add flag to make a copy from src to dest

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,77 @@ python3 main.py -j <filename>.json --src-address <ip_address> --src-port <port> 
 
 ### Architecture
 ![alt tag](https://raw.githubusercontent.com/wizeservices/wordpress-migration-cli/develop/docs/Architecture.png)
+
+
+###Scenarios
+####Source and destination machine
+All the scenarios below can be mixed, for instance ```python3 main.py -j file.json --dest-sudo --no-users --no-posts --fast-copy```. The json file used in the scenarios below is the following:
+```
+{
+    "src_address": "127.0.0.1",
+    "src_user": "vagrant",
+    "src_passw": "vagrant",
+    "src_wpath": "/var/www/app",
+    "src_port": 2222,
+    "dest_address": "127.0.0.1",
+    "dest_user": "vagrant",
+    "dest_passw": "vagrant",
+    "dest_port": 2200,
+    "dest_wpath": "/var/www/app/"
+}
+```
+
+######Normal flow where destination user is root
+![Alt text](http://i.imgur.com/AjfHpej.png)
+```
+python3 main.py -j file.json
+```
+
+######Normal flow where destination user is not root, but has sudo access
+![Alt text](http://i.imgur.com/SRpNAUB.png)
+```
+python3 main.py -j file.json --dest-sudo
+```
+
+######Normal without posts
+![Alt text](http://i.imgur.com/gXMXpyv.png)
+```
+python3 main.py -j file.json --no-posts
+```
+
+######Normal without users
+![Alt text](http://i.imgur.com/MJTm1pi.png)
+```
+python3 main.py -j file.json --no-users
+```
+
+######Fast copy flow
+For the fast copy flow you need to add the following key in the json file (because the fast copy needs access without password):
+```
+"dest_filekey": "<path_of_your_vagrantfile>/.vagrant/machines/default/virtualbox/private_key"
+```
+
+![Alt text](http://i.imgur.com/0wOoB3U.png)
+```
+python3 main.py -j file.json --fast-copy
+```
+
+
+####Destination machine
+######Fix destination url
+The json file contains:
+```
+{
+    "dest_address": "192.168.123.91",
+    "dest_user": "vagrant",
+    "dest_passw": "vagrant",
+    "dest_wpath": "/var/www/app/"
+}
+```
+
+![Alt text](http://i.imgur.com/2BclvSJ.png)
+
+```
+# destination.local is the current url registered for wordpress (it is a link to 192.168.123.91 in my /etc/hosts)
+python3 main.py -j fix.json --fix-destination-hostname --current-site destination.local --new-site 192.168.123.91
+```

--- a/main.py
+++ b/main.py
@@ -42,6 +42,10 @@ def handle_options():
                         help='The destination username is not root and needs '
                              'sudo')
 
+    parser.add_argument('--fast-copy', action='store_true',
+                        help='Transfer backup directly from source to '
+                             'destination')
+
     parser.add_argument('--fix-destination-hostname', action='store_true',
                         help='Change the hostname on wp_config and in the DB')
     parser.add_argument('--current-site', action='store', type=str,

--- a/process/common.py
+++ b/process/common.py
@@ -48,15 +48,15 @@ def _ssh_connect(args, direction):
         passw = args.__getattribute__(direction + '_passw')
         fkey = args.__getattribute__(direction + '_filekey')
         lib.log.info('Connecting to %s', address)
-        if fkey:
+        if passw:
+            ssh.connect(address, port=port, username=user, password=passw)
+        elif fkey:
             key = paramiko.RSAKey.from_private_key_file(fkey)
             # In case you need to set an user
             if user:
                 ssh.connect(address, port=port, username=user, pkey=key)
             else:
                 ssh.connect(address, port=port, pkey=key)
-        else:
-            ssh.connect(address, port=port, username=user, password=passw)
         lib.log.info('Connection successful')
         return ssh
     except Exception as exc:


### PR DESCRIPTION
#### What does this PR do?

Adds a new parameter to the tool to copy the backup directly from the source to the destination, instead of downloading and uploading the backup.
#### Where should the reviewer start?
1. Clone the branch.
2. Create a box from https://github.com/wizeservices/vagrant-trusty-lemp.
3. You need to have a wordpress installation previously deployed (If not create 2 boxes).
#### How should this be manually tested?

With fast copy:
`time python3 main.py -j file.json --fast-copy -n --dest-sudo`

Without fast copy:
`time python3 main.py -j file.json -n --dest-sudo`

Finally the time should be a lot more (if running from amazon to amazon) without fast copy. If you are testing with two boxes locally the time should be too different.
#### What are the relevant tickets?

Closes #11 
